### PR TITLE
adds healthcheck for docker compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,12 @@ services:
       - mawaqit-api-redis
     env_file:
       - .env
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:80/api/v1/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   mawaqit-api-redis:
     image: redis:alpine3.18


### PR DESCRIPTION
## Add Docker healthcheck to docker-compose.yaml

### What
Adds a `healthcheck` to the `mawaqit-api` service in `docker-compose.yaml`.

### Why
Without a healthcheck, Docker has no way to know if the container is actually serving requests or just running as a process. This is especially useful when other services `depend_on` mawaqit-api.

### How it was tested
Tested manually inside the running container:
```
wget -qO- http://127.0.0.1:80/api/v1/
# returns: {"Greetings": "Hello and Welcome..."}
```

### Notes
- The image uses BusyBox `wget` — `curl` is not available
- FastAPI redirects `/api/v1` → `/api/v1/` (trailing slash required), so the healthcheck targets `/api/v1/` directly to avoid the 307 redirect
- `start_period: 20s` gives the uvicorn process time to fully initialize before health checks begin